### PR TITLE
Fix typo in Webpack plugins example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module.exports = {
   },
   'plugins': [
     new LodashModuleReplacementPlugin,
-    new webpack.optimize.OccurenceOrderPlugin,
+    new webpack.optimize.OccurrenceOrderPlugin,
     new webpack.optimize.UglifyJsPlugin
   ]
 };


### PR DESCRIPTION
`OccurenceOrderPlugin` should be `OccurrenceOrderPlugin`

Both forms work in Webpack 1, the misspelled version has been removed in Webpack 2