### PR TITLE
`_.uniqueId` requires `toString` for its prefix.

### DIFF
--- a/src/mapping.js
+++ b/src/mapping.js
@@ -164,6 +164,7 @@ export const overrides = {
   'union': { 'flattening': true },
   'unionBy': { 'flattening': true },
   'unionWith': { 'flattening': true },
+  'uniqueId': { 'coercions': true },
   'upperCase': { 'unicode': true },
   'xor': { 'flattening': true },
   'xorBy': { 'flattening': true },


### PR DESCRIPTION
Without `toString`, running `_.uniqueId()` on an optimized build puts an `undefined` prefix through `identity`. `undefined + number` then turns into `NaN`.

An alternative fix that will simplify this (in lodash) is to not use `toString` on prefix unless a prefix is supplied.