### PR TITLE
Migrate webpack version in README.md from v1 to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ var webpack = require('webpack');
 
 module.exports = {
   'module': {
-    'loaders': [{
-      'loader': 'babel',
+    'rules': [{
+      'use': 'babel',
       'test': /\.js$/,
       'exclude': /node_modules/,
-      'query': {
+      'options': {
         'plugins': ['lodash'],
         'presets': [['env', { 'modules': false, 'targets': { 'node': 4 } }]]
       }
@@ -39,7 +39,6 @@ module.exports = {
   },
   'plugins': [
     new LodashModuleReplacementPlugin,
-    new webpack.optimize.OccurrenceOrderPlugin,
     new webpack.optimize.UglifyJsPlugin
   ]
 };


### PR DESCRIPTION
Change key names and delete OccurrenceOrderPlugin.
see: https://webpack.js.org/guides/migrating/#occurrenceorderplugin-is-now-on-by-default