### PR TITLE
babel-loader instead of babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var webpack = require('webpack');
 module.exports = {
   'module': {
     'rules': [{
-      'use': 'babel',
+      'use': 'babel-loader',
       'test': /\.js$/,
       'exclude': /node_modules/,
       'options': {


### PR DESCRIPTION
from webpack 2 onwards, loader suffix is mandatory.