### PR TITLE
Fix behavior change for createCompounder when deburring is not enabled

### DIFF
--- a/src/mapping.js
+++ b/src/mapping.js
@@ -49,7 +49,7 @@ export const features = {
     ['unary', '_baseUnary']
   ],
   'deburring': [
-    ['deburr', 'identity']
+    ['deburr', 'toString']
   ],
   'exotics': [
     ['_baseGetTag', '_objectToString'],


### PR DESCRIPTION
Found the problem through Webpack non-deterministic builds as described in https://github.com/lodash/lodash-webpack-plugin/issues/162, this pull request fixes a change in behavior in all functions that depend on [`createCompounder`](https://github.com/lodash/lodash/blob/npm/_createCompounder.js#L20) when `deburring` is not enabled:

- `camelCase`
- `kebabCase`
- `lowerCase`
- `snakeCase`
- `startCase`
- `upperCase`

Assuming these functions are expected to work with non-String arguments, such as `null` or `{}`, since that's the behavior in the full build of the library.

### The Bug 🐞 
When `deburring` is disabled, `deburr` will be replaced with `identity`, failing to coerce the argument to a `String` as it normally would, so `createCompounder` fails when [calling `replace`](https://github.com/lodash/lodash/blob/npm/_createCompounder.js#L20) if the function was called with any non-String argument.

### The Fix 🔨 
Substitute `deburr` with `toString` instead when `deburring` is disabled. This will ensure any arguments are coerced as usual, but no regex replacement will occur.