### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "test": "mocha --check-leaks --slow 1e3 -r @babel/register"
   },
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.19"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.44",
-    "@babel/core": "^7.0.0-beta.44",
+    "@babel/core": "^7.11.2",
     "@babel/preset-env": "^7.0.0-beta.44",
     "@babel/register": "^7.0.0-beta.44",
     "babel-loader": "^8.0.0-beta.2",


### PR DESCRIPTION
older version of babel and lodash has injection vulnerability. An attacker can inject malicious code via `sourceURL` since it is not sanitized for the user-provided code that leads to the `eval()` function.